### PR TITLE
use updated value reprs (REALs, BOZ consts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 (Unreleased)
+  * Update to fortran-src 0.7.0
+
 ## 0.2.0 (24 Nov 2021)
   * Update to fortran-src 0.6.0
   * Gather type info from COMMON blocks better (as they now support dimension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.3.0 (Unreleased)
-  * Update to fortran-src 0.7.0
+  * Update to fortran-src 0.8.0
 
 ## 0.2.0 (24 Nov 2021)
   * Update to fortran-src 0.6.0

--- a/fortran-vars.cabal
+++ b/fortran-vars.cabal
@@ -60,7 +60,7 @@ library
     , containers >=0.5.7.1
     , deepseq >=1.4.4.0
     , fgl >=5
-    , fortran-src >=0.7.0 && <0.8.0
+    , fortran-src >=0.8.0 && <0.9
     , fortran-src-extras >=0.2.0
     , text >=1.2.2.2
     , uniplate >=1.6.10
@@ -80,7 +80,7 @@ executable fortran-vars
     , containers >=0.5.7.1
     , deepseq >=1.4.4.0
     , fgl >=5
-    , fortran-src >=0.7.0 && <0.8.0
+    , fortran-src >=0.8.0 && <0.9
     , fortran-src-extras >=0.2.0
     , fortran-vars
     , text >=1.2.2.2
@@ -114,7 +114,7 @@ test-suite spec
     , containers >=0.5.7.1
     , deepseq >=1.4.4.0
     , fgl >=5
-    , fortran-src >=0.7.0 && <0.8.0
+    , fortran-src >=0.8.0 && <0.9
     , fortran-src-extras >=0.2.0
     , fortran-vars
     , hspec

--- a/fortran-vars.cabal
+++ b/fortran-vars.cabal
@@ -60,7 +60,7 @@ library
     , containers >=0.5.7.1
     , deepseq >=1.4.4.0
     , fgl >=5
-    , fortran-src >=0.6.0 && <0.7.0
+    , fortran-src >=0.7.0 && <0.8.0
     , fortran-src-extras >=0.2.0
     , text >=1.2.2.2
     , uniplate >=1.6.10
@@ -80,7 +80,7 @@ executable fortran-vars
     , containers >=0.5.7.1
     , deepseq >=1.4.4.0
     , fgl >=5
-    , fortran-src >=0.6.0 && <0.7.0
+    , fortran-src >=0.7.0 && <0.8.0
     , fortran-src-extras >=0.2.0
     , fortran-vars
     , text >=1.2.2.2
@@ -114,7 +114,7 @@ test-suite spec
     , containers >=0.5.7.1
     , deepseq >=1.4.4.0
     , fgl >=5
-    , fortran-src >=0.6.0 && <0.7.0
+    , fortran-src >=0.7.0 && <0.8.0
     , fortran-src-extras >=0.2.0
     , fortran-vars
     , hspec

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,7 @@ extra-source-files:
 
 dependencies:
 - base >=4.7 && <5
-- fortran-src >=0.6.0 && <0.7.0
+- fortran-src >=0.7.0 && <0.8.0
 - text >=1.2.2.2
 - bytestring >=0.10.8.1
 - containers >=0.5.7.1

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,7 @@ extra-source-files:
 
 dependencies:
 - base >=4.7 && <5
-- fortran-src >=0.7.0 && <0.8.0
+- fortran-src ^>= 0.8.0
 - text >=1.2.2.2
 - bytestring >=0.10.8.1
 - containers >=0.5.7.1

--- a/src/Language/Fortran/Vars/Assignments.hs
+++ b/src/Language/Fortran/Vars/Assignments.hs
@@ -17,6 +17,7 @@ import           Language.Fortran.AST           ( ProgramUnit
                                                 , DataGroup(..)
                                                 , Expression(..)
                                                 , Declarator(..)
+                                                , DeclaratorType(..)
                                                 , Value(..)
                                                 , aStrip
                                                 )
@@ -62,7 +63,7 @@ allAssignStmts pu =
     ]
     <> [ (, e) <$> ty
        | StParameter _ _ decls <- universeBi pu :: [Statement (Analysis a)]
-       , DeclVariable _ _ v _ (Just e) <- aStrip decls
+       , Declarator _ _ v ScalarDecl _ (Just e) <- aStrip decls
        , let ty = typeOf strt symt v
        ]
     <> [ res
@@ -98,8 +99,8 @@ declarators
   -> [Declarator (Analysis a)]
   -> [Either TypeError (Type, Expression (Analysis a))]
 declarators strt symt = concatMap f where
-  f (DeclVariable _ _ v _ (Just e)) = pure $ (, e) <$> typeOf strt symt v
-  f d@(DeclArray _ _ (ExpValue _ s (ValVariable v)) _ _ (Just (ExpInitialisation _ _ vals)))
+  f (Declarator _ _ v ScalarDecl _ (Just e)) = pure $ (, e) <$> typeOf strt symt v
+  f d@(Declarator _ _ (ExpValue _ s (ValVariable v)) ArrayDecl{} _ (Just (ExpInitialisation _ _ vals)))
     = case M.lookup v symt of
       Just (SVariable (TArray ty (Just dims)) _) ->
         let tys   = expandDimensions dims ty

--- a/src/Language/Fortran/Vars/Memory.hs
+++ b/src/Language/Fortran/Vars/Memory.hs
@@ -121,6 +121,5 @@ processCommon pu puModel =
                   in  M.insert commonName newBlock mbs
               f model (l1, l2) = let (model', _) = union model l1 l2 in model'
           in  foldl' f (symTable, mbs') (zip commBlockLocations varLocations)
-      declExpr (DeclVariable _ _ e _ _)   = e
-      declExpr (DeclArray    _ _ e _ _ _) = e
+      declExpr (Declarator _ _ e _ _ _) = e
   in  M.foldrWithKey processComm puModel commons

--- a/src/Language/Fortran/Vars/StorageClass.hs
+++ b/src/Language/Fortran/Vars/StorageClass.hs
@@ -30,9 +30,7 @@ storageClassStmt puModel (StAutomatic _ _ decls) = foldl' f
                                                           puModel
                                                           (aStrip decls)
  where
-  f m (DeclVariable _ _ varExp _ _) =
-    updateStorageClass (srcName varExp) Automatic m
-  f m (DeclArray _ _ varExp _ _ _) =
+  f m (Declarator _ _ varExp _ _ _) =
     updateStorageClass (srcName varExp) Automatic m
 storageClassStmt puModel (StSave _ _ (Just exps)) = foldl' f
                                                            puModel

--- a/src/Language/Fortran/Vars/StructureTable.hs
+++ b/src/Language/Fortran/Vars/StructureTable.hs
@@ -27,6 +27,7 @@ import           Language.Fortran.AST           ( Statement(..)
                                                 , ProgramFile
                                                 , TypeSpec(..)
                                                 , Declarator(..)
+                                                , DeclaratorType(..)
                                                 , aStrip
                                                 )
 import           Language.Fortran.Extras
@@ -61,17 +62,17 @@ itemToEntry st (StructUnion _ _ l) = [UnionEntry $ handleUnion st <$> aStrip l]
 itemToEntry _  StructStructure{}   = []
 
 -- TODO take into account length, should override default typespecs
--- | Given the `TypeSpec` and `Declerator` found in a field entry create a
--- `StructureTableEntry`
+-- | Given the 'TypeSpec' and 'Declarator' found in a field entry create a
+--   'StructureTableEntry'
 handleDeclarator
   :: SymbolTable
   -> TypeSpec (Analysis a)
   -> Declarator (Analysis a)
   -> Maybe StructureTableEntry
-handleDeclarator st ty (DeclVariable _ _ expr _ _) =
+handleDeclarator st ty (Declarator _ _ expr ScalarDecl _ _) =
   let scalarTy = typeSpecToScalarType st ty
   in  expToName expr >>= \name -> Just $ FieldEntry name scalarTy
-handleDeclarator st ty (DeclArray _ _ expr dims _ _) =
+handleDeclarator st ty (Declarator _ _ expr (ArrayDecl dims) _ _) =
   let arrayty = typeSpecToArrayType st (aStrip dims) ty
   in  expToName expr >>= \name -> Just $ FieldEntry name arrayty
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,5 @@ packages:
 save-hackage-creds: false
 
 extra-deps:
-- fortran-src-0.6.0
+- fortran-src-0.7.0@sha256:6d7e1eb8befaa703a679ad162da3462fcd3a3fb7c2416436260609227ec3e4f0,7811
 - fortran-src-extras-0.2.0@sha256:13afb3b30c5cd93213a8869d2571a8fa4d65b9a9429765f6aef2cf47c70b0dea,1991

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,5 @@ packages:
 save-hackage-creds: false
 
 extra-deps:
-- fortran-src-0.7.0@sha256:6d7e1eb8befaa703a679ad162da3462fcd3a3fb7c2416436260609227ec3e4f0,7811
+- fortran-src-0.8.0@sha256:9ab6d1f26452139d44860790d340c900253154b8b4b1bb695d8140be686d6aa1,7811
 - fortran-src-extras-0.2.0@sha256:13afb3b30c5cd93213a8869d2571a8fa4d65b9a9429765f6aef2cf47c70b0dea,1991

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: fortran-src-0.7.0@sha256:6d7e1eb8befaa703a679ad162da3462fcd3a3fb7c2416436260609227ec3e4f0,7811
+    hackage: fortran-src-0.8.0@sha256:9ab6d1f26452139d44860790d340c900253154b8b4b1bb695d8140be686d6aa1,7811
     pantry-tree:
       size: 8809
-      sha256: 2a7e0fbb92cfb8fcaed0bb457d40842d14842d89c9c47258196508d063ae9db6
+      sha256: 2d93aa453f01092d454f0cde100b481ed61057ecf0dc6ecb147aa88e0c02c012
   original:
-    hackage: fortran-src-0.7.0@sha256:6d7e1eb8befaa703a679ad162da3462fcd3a3fb7c2416436260609227ec3e4f0,7811
+    hackage: fortran-src-0.8.0@sha256:9ab6d1f26452139d44860790d340c900253154b8b4b1bb695d8140be686d6aa1,7811
 - completed:
     hackage: fortran-src-extras-0.2.0@sha256:13afb3b30c5cd93213a8869d2571a8fa4d65b9a9429765f6aef2cf47c70b0dea,1991
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: fortran-src-0.6.0@sha256:63f0cae9fb14466026caad7f1e7adfbda4f53496cdc7a74b5f2783ff472731a7,5408
+    hackage: fortran-src-0.7.0@sha256:6d7e1eb8befaa703a679ad162da3462fcd3a3fb7c2416436260609227ec3e4f0,7811
     pantry-tree:
-      size: 5344
-      sha256: 06a7299de27edef4841edf003f740cbf12e0abcab0ffa5a32adbb7be89e5c28e
+      size: 8809
+      sha256: 2a7e0fbb92cfb8fcaed0bb457d40842d14842d89c9c47258196508d063ae9db6
   original:
-    hackage: fortran-src-0.6.0
+    hackage: fortran-src-0.7.0@sha256:6d7e1eb8befaa703a679ad162da3462fcd3a3fb7c2416436260609227ec3e4f0,7811
 - completed:
     hackage: fortran-src-extras-0.2.0@sha256:13afb3b30c5cd93213a8869d2571a8fa4d65b9a9429765f6aef2cf47c70b0dea,1991
     pantry-tree:

--- a/test/AssignmentsSpec.hs
+++ b/test/AssignmentsSpec.hs
@@ -36,7 +36,7 @@ spec = describe "Grab assignment exprs" $ do
     length stmts `shouldBe` 9
     map fst stmts `shouldBe` replicate 9 (TReal 4)
     let getVal = \case
-          ExpValue _ _ (ValInteger s) -> s
+          ExpValue _ _ (ValInteger s _) -> s
           _                           -> error "Not value"
     map (getVal . snd) stmts
       `shouldBe` ["1", "0", "0", "0", "1", "0", "0", "0", "1"]

--- a/test/EvalSpec.hs
+++ b/test/EvalSpec.hs
@@ -28,8 +28,8 @@ dSym :: SymbolTable
 dSym = M.empty
 
 true, false :: Expression A0
-true = ExpValue () dSpan $ ValLogical ".TRUE."
-false = ExpValue () dSpan $ ValLogical ".FALSE."
+true = ExpValue () dSpan $ ValLogical True Nothing
+false = ExpValue () dSpan $ ValLogical False Nothing
 
 foobar :: Expression A0
 foobar = ExpValue () dSpan $ ValVariable "foobar"
@@ -84,6 +84,6 @@ spec = describe "Boolean constant folding" $ do
     evalWithShortcircuit dSym ex `shouldBe` Right (Logical True)
   it "Can handle conditions with non-logical logic" $ do
     -- .TRUE. .EQ. 1
-    let vx = ExpValue () dSpan $ ValInteger "1"
+    let vx = ExpValue () dSpan $ ValInteger "1" Nothing
         ex = ExpBinary () dSpan EQ true vx
     evalWithShortcircuit dSym ex `shouldBe` Right (Logical True)


### PR DESCRIPTION
Lazy for now, specifically with BOZs: we print out the parsed BOZ into a
string so that we can continue relying on fortran-vars' BOZ processing.

Some internals are now more slightly more general, being able to use
explicitly handle kind parameters -- likely doesn't matter for most F77
compilers, but does for F90 and beyond.