### PR TITLE
Typecheck non logical usage of logical operators

### DIFF
--- a/src/Language/Fortran/Vars/TypeCheck.hs
+++ b/src/Language/Fortran/Vars/TypeCheck.hs
@@ -226,8 +226,19 @@ typeOfBinaryExp' sp op t1 t2
     _ -> error "shit 2"
   |
   -- Logical
+  -- NB when integer's are used with logical operators you get bitwise
+  -- arithmetic behaviour
     op `elem` [And, Or, Equivalent, NotEquivalent, XOr]
-  = Right . TLogical . fromJust $ max <$> k1 <*> k2
+  = let
+      ty = case (t1, t2) of
+        (TLogical _, TLogical _) -> Right . TLogical
+        (TInteger _, _         ) -> Right . TInteger
+        (_         , TInteger _) -> Right . TInteger
+        (TByte _   , _         ) -> Right . TInteger
+        (_         , TByte _   ) -> Right . TInteger
+        _                        -> const
+          (Left $ typeError sp "Unexpected types used with logical operators")
+    in  ty . fromJust $ max <$> k1 <*> k2
   |
   -- Arithmetic
     op `elem` [Addition, Subtraction, Multiplication, Division, Exponentiation]

--- a/test/TypeCheckSpec.hs
+++ b/test/TypeCheckSpec.hs
@@ -273,10 +273,11 @@ spec = do
     it "Logical Expression" $ do
       (typeof, rhs) <- helper path puName
       typeof (rhs "le1") `shouldBe` Right (TLogical 4)
-      typeof (rhs "le2") `shouldBe` Right (TLogical 8)
+      typeof (rhs "le2") `shouldBe` Right (TInteger 8)
       typeof (rhs "le3") `shouldBe` Right (TLogical 2)
       typeof (rhs "le4") `shouldBe` Right (TLogical 2)
       typeof (rhs "le5") `shouldBe` Right (TLogical 4)
+      typeof (rhs "le6") `shouldSatisfy` typeError
 
     it "More expressions" $ do
       (typeof, rhs) <- helper path puName

--- a/test/type_check/expression.f
+++ b/test/type_check/expression.f
@@ -80,10 +80,11 @@ C     Relational Expression
 
 C     Logical Expression
       le1 = l .AND. l2    ! logical 4
-      le2 = i8 .OR. l     ! logical 8
+      le2 = i8 .OR. l     ! integer 8
       le3 = l1 .XOR. l2   ! logical 2
       le4 = l1 .EQV. l2   ! logical 2
       le5 = l  .NEQV. l2  ! logical 4
+      le6 = r8 .or. l     ! error
 
 C     More expressions
       e1 = 42 * i8 - i4             ! int 8


### PR DESCRIPTION
This was in the original fortran-vars but seems to have got missed in
the import. See the GFortran docs for the behaviour:
  https://gcc.gnu.org/onlinedocs/gfortran/Bitwise-logical-operators.html

I made it give type errors for unexpected operands, which it didn't do before, but catch integer and byte operands to make the resulting type integer.