### PR TITLE
Support better type checking of array sections 

### DIFF
--- a/test/TypeCheckSpec.hs
+++ b/test/TypeCheckSpec.hs
@@ -29,6 +29,7 @@ import           Language.Fortran.Vars.SymbolTable
                                                 ( collectSymbols )
 import           Language.Fortran.Vars.StructureTable
                                                 ( collectStructures )
+import Language.Fortran.Analysis.SemanticTypes (Dims(DimsAssumedSize))
 
 -- | Given a varaible name, 'RHSFunc' search assignment statements within a program
 -- unit and returns the RHS of first assignment statement whose LHS matches the
@@ -183,9 +184,10 @@ spec = do
 
     it "Index ranges" $ do
       (typeof, rhs) <- helper path puName
-      typeof (rhs "i1") `shouldBe` Right (TArray (TInteger 4) (dess1 1 10))
-      typeof (rhs "i2") `shouldBe` Right (TArray (TInteger 4) (dess1 1 10))
-      typeof (rhs "i3") `shouldBe` Right (TArray (TInteger 4) (DimsExplicitShape (Dim (Just 1) Nothing :| [])))
+      typeof (rhs "i1") `shouldBe` Right (TArray (TInteger 4) (dess1 1 3))
+      typeof (rhs "i2") `shouldBe` Right (TArray (TInteger 4) (dess1 1 1))
+      typeof (rhs "i3") `shouldBe` Right (TArray (TInteger 4) (DimsAssumedSize Nothing (Just 3)))
+      typeof (rhs "i4") `shouldBe` Right (TArray (TInteger 2) (dess1 1 6))
 
     it "Erroneous expressions" $ do
       -- These expressions aren't valid but any subscript can be assumed to

--- a/test/type_check/array_and_substring.f
+++ b/test/type_check/array_and_substring.f
@@ -4,6 +4,7 @@
       integer N
       integer c(N)        ! adjustable
       integer d(10, *)    ! assumed-size
+      integer*2 e(10, 10)
 
 C     test the types of RHS expressions
       arr1 = a(1)
@@ -16,6 +17,7 @@ c     test ranges
       i1   = a(3:5)
       i2   = a(1:1)
       i3   = c(3:)
+      i4   = e(5:, 2)
 
 c     test erroneous expressions where we have too many indices
       err1 = a(2, 3)


### PR DESCRIPTION
Previously it would just return the type of the array, not taking into
account what the section is referring to, which is somewhat ok for 1
dimensional arrays but for more dimensions it really should tell us the
expression is a single dimensional array.

This helps us check whether interfaces usage is valid, which does care
about the dimensionality.