### PR TITLE
--pretty mode to display a more digestible form of the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Variables and array elements are resolved to range of memory by referencing the 
 command-line tool that dumps the symbol table and storage table of the input program in JSON format.
 
 ```
-fortran-vars (-v|--fortranVersion VERSION) [-I|--include DIRECTORY] FILE
+fortran-vars (-v|--fortranVersion VERSION) [-I|--include DIRECTORY] FILE [--pretty]
 ```
 
 ## Build

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,8 +19,6 @@ import           Options.Applicative
 
 import qualified Language.Fortran.Parser as Parser
 
-import qualified Language.Fortran.Extras.RunOptions as RO
-
 programDesc, programHeader :: String
 programDesc =
   "Generate symbol table and storage table from the AST of FORTRAN source"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,14 +3,23 @@ module Main where
 import           Language.Fortran.Extras.Encoding
                                                 ( commonEncode )
 import           Language.Fortran.Extras
-                                                ( withProgramAnalysis )
+                                                ( withToolOptionsAndProgramAnalysis )
 import           Language.Fortran.Vars          ( programFileModel )
+import           Language.Fortran.Vars.Types    ( ProgramFileModel
+                                                , SymbolTableEntry(..)
+                                                )
+import           Language.Fortran.AST           ( ProgramUnitName(..) )
 
 import qualified Data.ByteString.Lazy.Char8    as LB
-
-import           Control.Monad                  ( unless )
 import qualified Data.Map                      as M
-                                                ( null )
+import           Control.Monad                  ( unless )
+import           System.Environment             ( getArgs )
+import           Text.Printf                    ( printf )
+import           Options.Applicative
+
+import qualified Language.Fortran.Parser as Parser
+
+import qualified Language.Fortran.Extras.RunOptions as RO
 
 programDesc, programHeader :: String
 programDesc =
@@ -18,7 +27,80 @@ programDesc =
 programHeader = programDesc
 
 main :: IO ()
-main = withProgramAnalysis programDesc programHeader $ \pf -> do
-    -- <String, (<String, Entry>,<String, MemoryBlock>)>
-  let pfm = programFileModel pf
-  unless (M.null pfm) $ LB.putStrLn $ commonEncode pfm
+main = do
+  args <- getArgs
+  withToolOptionsAndProgramAnalysis programDesc programHeader prettyFlagParser $ \prettyFlag pf -> do
+    let pfm = programFileModel pf
+    unless (M.null pfm) $ 
+      if prettyFlag
+        then putStrLn $ prettyPrintModel pfm
+        else LB.putStrLn $ commonEncode pfm
+
+prettyFlagParser :: Parser Bool
+prettyFlagParser = 
+   flag False True
+      (  long "pretty"
+      <> help "Pretty print the program file model as an ASCII table"
+    )
+
+-- | Pretty print the program file model as an ASCII table
+prettyPrintModel :: ProgramFileModel -> String
+prettyPrintModel pfm = unlines $ [header, separator] ++ rows ++ [separator, footer]
+  where
+    -- Column widths
+    nameWidth = 30
+    symbolsWidth = 12
+    paramsWidth = 12
+    varsWidth = 12
+    blocksWidth = 12
+    
+    -- Table structure
+    header = printf "| %-*s | %-*s | %-*s | %-*s | %-*s |" 
+      nameWidth "Program Unit"
+      symbolsWidth "Symbols"
+      paramsWidth "Parameters"
+      varsWidth "Variables"
+      blocksWidth "Memory Blocks"
+    
+    separator = "+" ++ replicate (nameWidth + 2) '-' 
+             ++ "+" ++ replicate (symbolsWidth + 2) '-'
+             ++ "+" ++ replicate (paramsWidth + 2) '-'
+             ++ "+" ++ replicate (varsWidth + 2) '-'
+             ++ "+" ++ replicate (blocksWidth + 2) '-' ++ "+"
+    
+    rows = map formatUnit (M.toList pfm)
+    
+    formatUnit (punName, (symTable, storageTable)) =
+      let totalSyms = M.size symTable
+          params = length $ filter isParameter $ M.elems symTable
+          vars = length $ filter isVariable $ M.elems symTable
+          blocks = M.size storageTable
+          name = showPUN punName
+      in printf "| %-*s | %*d | %*d | %*d | %*d |"
+           nameWidth (truncate' nameWidth name)
+           (symbolsWidth - 1) totalSyms
+           (paramsWidth - 1) params
+           (varsWidth - 1) vars
+           (blocksWidth - 1) blocks
+    
+    footer = printf "| %-*s | %*d | %*d | %*d | %*d |"
+      nameWidth "TOTAL"
+      (symbolsWidth - 1) (sum [M.size st | (st, _) <- M.elems pfm])
+      (paramsWidth - 1) (sum [length $ filter isParameter $ M.elems st | (st, _) <- M.elems pfm])
+      (varsWidth - 1) (sum [length $ filter isVariable $ M.elems st | (st, _) <- M.elems pfm])
+      (blocksWidth - 1) (sum [M.size storage | (_, storage) <- M.elems pfm])
+    
+    isParameter (SParameter _ _) = True
+    isParameter _ = False
+    
+    isVariable (SVariable _ _) = True
+    isVariable _ = False
+    
+    truncate' n s 
+      | length s <= n = s
+      | otherwise = take (n - 3) s ++ "..."
+    
+    showPUN (Named n) = n
+    showPUN (NamelessBlockData) = "<anonymous block data>"
+    showPUN (NamelessComment) = "<comment>"
+    showPUN (NamelessMain) = "<main>"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,23 +5,13 @@ import           Language.Fortran.Extras.Encoding
 import           Language.Fortran.Extras
                                                 ( withToolOptionsAndProgramAnalysis )
 import           Language.Fortran.Vars          ( programFileModel )
-import           Language.Fortran.Vars.Types    ( ProgramFileModel
-                                                , SymbolTableEntry(..)
-                                                , MemoryBlock(..)
-                                                )
-import           Language.Fortran.AST           ( ProgramUnitName(..) )
-import           Language.Fortran.Vars.Rep      ( Type
-                                                , ExpVal(..)
-                                                )
-import           Language.Fortran.PrettyPrint   ( pprintAndRender )
-import           Language.Fortran.Version       ( FortranVersion(..) )
+import           Language.Fortran.Vars.PrettyPrintModel
+                                                ( prettyPrintModel )
 
 import qualified Data.ByteString.Lazy.Char8    as LB
 import qualified Data.Map                      as M
-import           Data.List                      ( intercalate )
 import           Control.Monad                  ( unless )
 import           System.Environment             ( getArgs )
-import           Text.Printf                    ( printf )
 import           Options.Applicative            ( Parser
                                                 , long
                                                 , help
@@ -49,111 +39,4 @@ prettyFlagParser =
       (  long "pretty"
       <> help "Pretty print the program file model as an ASCII table"
     )
-
--- | Pretty print the program file model as an ASCII table showing detailed information
-prettyPrintModel :: ProgramFileModel -> String
-prettyPrintModel pfm = unlines $ concatMap formatProgramUnit (M.toList pfm)
-  where
-    formatProgramUnit (punName, (symTable, storageTable)) =
-      let unitName = showPUN punName
-          unitHeader = "\n" ++ replicate 100 '=' ++ "\n" 
-                    ++ "Program Unit: " ++ unitName ++ "\n"
-                    ++ replicate 100 '='
-          combinedTable = if M.null symTable
-                          then "\n(No symbols)"
-                          else formatCombinedTable symTable storageTable
-      in [unitHeader, combinedTable]
-    
-    formatCombinedTable symTable storageTable = 
-      let tableHeader = "\n\n" ++ combinedHeader ++ "\n" ++ combinedSep
-          symRows = map (formatSymbol storageTable) (M.toList symTable)
-      in unlines (tableHeader : symRows ++ [combinedSep])
-    
-    -- Column widths for combined table
-    nameW = 20
-    tagW = 10
-    typeW = 30
-    blockW = 15
-    offsetW = 8
-    sizeW = 10
-    classW = 12
-    
-    combinedHeader = printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
-      nameW "Name" tagW "Tag" typeW "Type" blockW "Block/Value" offsetW "Offset" sizeW "Size" classW "Class"
-    
-    combinedSep = "+" ++ replicate (nameW + 2) '-'
-               ++ "+" ++ replicate (tagW + 2) '-'
-               ++ "+" ++ replicate (typeW + 2) '-'
-               ++ "+" ++ replicate (blockW + 2) '-'
-               ++ "+" ++ replicate (offsetW + 2) '-'
-               ++ "+" ++ replicate (sizeW + 2) '-'
-               ++ "+" ++ replicate (classW + 2) '-' ++ "+"
-    
-    formatSymbol storageTable (name, entry) = case entry of
-      SParameter ty val -> 
-        printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
-          nameW (trunc nameW name)
-          tagW "Parameter"
-          typeW (trunc typeW $ showType ty)
-          blockW (trunc blockW $ showExpVal val)
-          offsetW ""
-          sizeW ""
-          classW "Constant"
-      
-      SVariable ty (blockName, offset) ->
-        let (sizeStr, classStr) = case M.lookup blockName storageTable of
-              Nothing -> ("", "")
-              Just memBlock -> 
-                let size = case blockSize memBlock of
-                      Just s -> show s
-                      Nothing -> "dynamic"
-                    cls = show $ storageClass memBlock
-                in (size, cls)
-        in printf "| %-*s | %-*s | %-*s | %-*s | %-*d | %-*s | %-*s |"
-             nameW (trunc nameW name)
-             tagW "Variable"
-             typeW (trunc typeW $ showType ty)
-             blockW (trunc blockW blockName)
-             offsetW offset
-             sizeW (trunc sizeW sizeStr)
-             classW (trunc classW classStr)
-      
-      SDummy ty ->
-        printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
-          nameW (trunc nameW name)
-          tagW "Dummy"
-          typeW (trunc typeW $ showType ty)
-          blockW ""
-          offsetW ""
-          sizeW ""
-          classW ""
-      
-      SExternal ty ->
-        printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
-          nameW (trunc nameW name)
-          tagW "External"
-          typeW (trunc typeW $ showType ty)
-          blockW ""
-          offsetW ""
-          sizeW ""
-          classW ""
-    
-    trunc n s 
-      | length s <= n = s
-      | otherwise = take (n - 3) s ++ "..."
-    
-    showPUN (Named n) = n
-    showPUN (NamelessBlockData) = "<anonymous block data>"
-    showPUN (NamelessComment) = "<comment>"
-    showPUN (NamelessMain) = "<main>"
-    
-    showExpVal (Int i) = show i
-    showExpVal (Real d) = show d
-    showExpVal (Str s) = show s
-    showExpVal (Logical b) = show b
-    showExpVal (Boz b) = show b
-
--- | Format a type for display using fortran-src's pretty printer
-showType :: Type -> String
-showType ty = pprintAndRender Fortran90 ty (Just 0)
 

--- a/fortran-vars.cabal
+++ b/fortran-vars.cabal
@@ -101,6 +101,7 @@ library
     , fortran-src >=0.15.0 && <0.16
     , fortran-src-extras >=0.5.0 && <0.6
     , mtl
+    , optparse-applicative ==0.17.1.0
     , text >=1.2.2.2
     , uniplate >=1.6.10
   default-language: Haskell2010
@@ -153,6 +154,7 @@ executable fortran-vars
     , fortran-src-extras >=0.5.0 && <0.6
     , fortran-vars
     , mtl
+    , optparse-applicative ==0.17.1.0
     , text >=1.2.2.2
     , uniplate >=1.6.10
   default-language: Haskell2010
@@ -220,6 +222,7 @@ test-suite spec
     , fortran-vars
     , hspec
     , mtl
+    , optparse-applicative ==0.17.1.0
     , text >=1.2.2.2
     , uniplate >=1.6.10
   default-language: Haskell2010

--- a/fortran-vars.cabal
+++ b/fortran-vars.cabal
@@ -44,6 +44,7 @@ library
       Language.Fortran.Vars.Memory
       Language.Fortran.Vars.MemoryLocation
       Language.Fortran.Vars.Orphans
+      Language.Fortran.Vars.PrettyPrintModel
       Language.Fortran.Vars.PureExpression
       Language.Fortran.Vars.Range
       Language.Fortran.Vars.Rep

--- a/package.yaml
+++ b/package.yaml
@@ -75,6 +75,7 @@ dependencies:
 - deepseq >=1.4.4.0
 - fortran-src-extras ^>= 0.5.0
 - mtl # TODO ver
+- optparse-applicative ==0.17.1.0
 
 library:
   source-dirs: src

--- a/src/Language/Fortran/Vars/PrettyPrintModel.hs
+++ b/src/Language/Fortran/Vars/PrettyPrintModel.hs
@@ -10,6 +10,7 @@ import           Language.Fortran.Vars.Types    ( ProgramFileModel
                                                 , StorageTable
                                                 , SymbolTable
                                                 )
+import           Language.Fortran.Vars.Types.SymbolTable ( MemoryBlockName )
 import           Language.Fortran.AST           ( ProgramUnitName(..) )
 import           Language.Fortran.Vars.Rep      ( Type
                                                 , ExpVal(..)

--- a/src/Language/Fortran/Vars/PrettyPrintModel.hs
+++ b/src/Language/Fortran/Vars/PrettyPrintModel.hs
@@ -61,7 +61,7 @@ prettyPrintModel pfm = unlines $ concatMap formatProgramUnit (M.toList pfm)
                <> "+" <> replicate (sizeW + 2) '-'
                <> "+" <> replicate (classW + 2) '-' <> "+"
     
-    formatSymbol :: M.Map String MemoryBlock -> (String, SymbolTableEntry) -> String
+    formatSymbol :: M.Map MemoryBlockName MemoryBlock -> (String, SymbolTableEntry) -> String
     formatSymbol storageTable (name, entry) = case entry of
       SParameter ty val -> 
         printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
@@ -85,10 +85,10 @@ prettyPrintModel pfm = unlines $ concatMap formatProgramUnit (M.toList pfm)
         in printf "| %-*s | %-*s | %-*s | %-*s | %-*d | %-*s | %-*s |"
              nameW (trunc nameW name)
              tagW "Variable"
-             typeW (trunc typeW $ showType ty)
+             typeW  (trunc typeW $ showType ty)
              blockW (trunc blockW blockName)
              offsetW offset
-             sizeW (trunc sizeW sizeStr)
+             sizeW  (trunc sizeW sizeStr)
              classW (trunc classW classStr)
       
       SDummy ty ->

--- a/src/Language/Fortran/Vars/PrettyPrintModel.hs
+++ b/src/Language/Fortran/Vars/PrettyPrintModel.hs
@@ -1,0 +1,126 @@
+-- | Pretty printing utilities for Fortran variable analysis results
+
+module Language.Fortran.Vars.PrettyPrintModel
+  ( prettyPrintModel
+  ) where
+
+import           Language.Fortran.Vars.Types    ( ProgramFileModel
+                                                , SymbolTableEntry(..)
+                                                , MemoryBlock(..)
+                                                )
+import           Language.Fortran.AST           ( ProgramUnitName(..) )
+import           Language.Fortran.Vars.Rep      ( Type
+                                                , ExpVal(..)
+                                                )
+import           Language.Fortran.PrettyPrint   ( pprintAndRender )
+import           Language.Fortran.Version       ( FortranVersion(..) )
+
+import qualified Data.Map                      as M
+import           Text.Printf                    ( printf )
+
+-- | Pretty print the program file model as an ASCII table showing detailed information
+prettyPrintModel :: ProgramFileModel -> String
+prettyPrintModel pfm = unlines $ concatMap formatProgramUnit (M.toList pfm)
+  where
+    formatProgramUnit (punName, (symTable, storageTable)) =
+      let unitName = showPUN punName
+          unitHeader = "\n" ++ replicate 100 '=' ++ "\n" 
+                    ++ "Program Unit: " ++ unitName ++ "\n"
+                    ++ replicate 100 '='
+          combinedTable = if M.null symTable
+                          then "\n(No symbols)"
+                          else formatCombinedTable symTable storageTable
+      in [unitHeader, combinedTable]
+    
+    formatCombinedTable symTable storageTable = 
+      let tableHeader = "\n\n" ++ combinedHeader ++ "\n" ++ combinedSep
+          symRows = map (formatSymbol storageTable) (M.toList symTable)
+      in unlines (tableHeader : symRows ++ [combinedSep])
+    
+    -- Column widths for combined table
+    nameW = 20
+    tagW = 10
+    typeW = 30
+    blockW = 15
+    offsetW = 8
+    sizeW = 10
+    classW = 12
+    
+    combinedHeader = printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
+      nameW "Name" tagW "Tag" typeW "Type" blockW "Block/Value" offsetW "Offset" sizeW "Size" classW "Class"
+    
+    combinedSep = "+" ++ replicate (nameW + 2) '-'
+               ++ "+" ++ replicate (tagW + 2) '-'
+               ++ "+" ++ replicate (typeW + 2) '-'
+               ++ "+" ++ replicate (blockW + 2) '-'
+               ++ "+" ++ replicate (offsetW + 2) '-'
+               ++ "+" ++ replicate (sizeW + 2) '-'
+               ++ "+" ++ replicate (classW + 2) '-' ++ "+"
+    
+    formatSymbol storageTable (name, entry) = case entry of
+      SParameter ty val -> 
+        printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
+          nameW (trunc nameW name)
+          tagW "Parameter"
+          typeW (trunc typeW $ showType ty)
+          blockW (trunc blockW $ showExpVal val)
+          offsetW ""
+          sizeW ""
+          classW "Constant"
+      
+      SVariable ty (blockName, offset) ->
+        let (sizeStr, classStr) = case M.lookup blockName storageTable of
+              Nothing -> ("", "")
+              Just memBlock -> 
+                let size = case blockSize memBlock of
+                      Just s -> show s
+                      Nothing -> "dynamic"
+                    cls = show $ storageClass memBlock
+                in (size, cls)
+        in printf "| %-*s | %-*s | %-*s | %-*s | %-*d | %-*s | %-*s |"
+             nameW (trunc nameW name)
+             tagW "Variable"
+             typeW (trunc typeW $ showType ty)
+             blockW (trunc blockW blockName)
+             offsetW offset
+             sizeW (trunc sizeW sizeStr)
+             classW (trunc classW classStr)
+      
+      SDummy ty ->
+        printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
+          nameW (trunc nameW name)
+          tagW "Dummy"
+          typeW (trunc typeW $ showType ty)
+          blockW ""
+          offsetW ""
+          sizeW ""
+          classW ""
+      
+      SExternal ty ->
+        printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
+          nameW (trunc nameW name)
+          tagW "External"
+          typeW (trunc typeW $ showType ty)
+          blockW ""
+          offsetW ""
+          sizeW ""
+          classW ""
+    
+    trunc n s 
+      | length s <= n = s
+      | otherwise = take (n - 3) s ++ "..."
+    
+    showPUN (Named n) = n
+    showPUN (NamelessBlockData) = "<anonymous block data>"
+    showPUN (NamelessComment) = "<comment>"
+    showPUN (NamelessMain) = "<main>"
+    
+    showExpVal (Int i) = show i
+    showExpVal (Real d) = show d
+    showExpVal (Str s) = show s
+    showExpVal (Logical b) = show b
+    showExpVal (Boz b) = show b
+
+-- | Format a type for display using fortran-src's pretty printer
+showType :: Type -> String
+showType ty = pprintAndRender Fortran90 ty (Just 0)

--- a/src/Language/Fortran/Vars/PrettyPrintModel.hs
+++ b/src/Language/Fortran/Vars/PrettyPrintModel.hs
@@ -7,6 +7,8 @@ module Language.Fortran.Vars.PrettyPrintModel
 import           Language.Fortran.Vars.Types    ( ProgramFileModel
                                                 , SymbolTableEntry(..)
                                                 , MemoryBlock(..)
+                                                , StorageTable
+                                                , SymbolTable
                                                 )
 import           Language.Fortran.AST           ( ProgramUnitName(..) )
 import           Language.Fortran.Vars.Rep      ( Type
@@ -22,20 +24,22 @@ import           Text.Printf                    ( printf )
 prettyPrintModel :: ProgramFileModel -> String
 prettyPrintModel pfm = unlines $ concatMap formatProgramUnit (M.toList pfm)
   where
+    formatProgramUnit :: (ProgramUnitName, (SymbolTable, StorageTable)) -> [String]
     formatProgramUnit (punName, (symTable, storageTable)) =
       let unitName = showPUN punName
-          unitHeader = "\n" ++ replicate 100 '=' ++ "\n" 
-                    ++ "Program Unit: " ++ unitName ++ "\n"
-                    ++ replicate 100 '='
+          unitHeader = "\n" <> replicate 100 '=' <> "\n" 
+                    <> "Program Unit: " <> unitName <> "\n"
+                    <> replicate 100 '='
           combinedTable = if M.null symTable
                           then "\n(No symbols)"
                           else formatCombinedTable symTable storageTable
       in [unitHeader, combinedTable]
-    
+
+    formatCombinedTable :: SymbolTable -> StorageTable -> String
     formatCombinedTable symTable storageTable = 
-      let tableHeader = "\n\n" ++ combinedHeader ++ "\n" ++ combinedSep
+      let tableHeader = "\n\n" <> combinedSep <> "\n" <> combinedHeader <> "\n" <> combinedSep
           symRows = map (formatSymbol storageTable) (M.toList symTable)
-      in unlines (tableHeader : symRows ++ [combinedSep])
+      in unlines (tableHeader : symRows <> [combinedSep])
     
     -- Column widths for combined table
     nameW = 20
@@ -49,14 +53,15 @@ prettyPrintModel pfm = unlines $ concatMap formatProgramUnit (M.toList pfm)
     combinedHeader = printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
       nameW "Name" tagW "Tag" typeW "Type" blockW "Block/Value" offsetW "Offset" sizeW "Size" classW "Class"
     
-    combinedSep = "+" ++ replicate (nameW + 2) '-'
-               ++ "+" ++ replicate (tagW + 2) '-'
-               ++ "+" ++ replicate (typeW + 2) '-'
-               ++ "+" ++ replicate (blockW + 2) '-'
-               ++ "+" ++ replicate (offsetW + 2) '-'
-               ++ "+" ++ replicate (sizeW + 2) '-'
-               ++ "+" ++ replicate (classW + 2) '-' ++ "+"
+    combinedSep = "+" <> replicate (nameW + 2) '-'
+               <> "+" <> replicate (tagW + 2) '-'
+               <> "+" <> replicate (typeW + 2) '-'
+               <> "+" <> replicate (blockW + 2) '-'
+               <> "+" <> replicate (offsetW + 2) '-'
+               <> "+" <> replicate (sizeW + 2) '-'
+               <> "+" <> replicate (classW + 2) '-' <> "+"
     
+    formatSymbol :: M.Map String MemoryBlock -> (String, SymbolTableEntry) -> String
     formatSymbol storageTable (name, entry) = case entry of
       SParameter ty val -> 
         printf "| %-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %-*s |"
@@ -108,7 +113,7 @@ prettyPrintModel pfm = unlines $ concatMap formatProgramUnit (M.toList pfm)
     
     trunc n s 
       | length s <= n = s
-      | otherwise = take (n - 3) s ++ "..."
+      | otherwise = take (n - 3) s <> "..."
     
     showPUN (Named n) = n
     showPUN (NamelessBlockData) = "<anonymous block data>"

--- a/src/Language/Fortran/Vars/Types/SymbolTable.hs
+++ b/src/Language/Fortran/Vars/Types/SymbolTable.hs
@@ -18,9 +18,9 @@ type SymbolTable = Map Name SymbolTableEntry
 -- | An entry in the 'SymbolTable' for some variable
 data SymbolTableEntry
   = SParameter { parType :: Type , parVal :: ExpVal }
-  | SVariable { varType :: Type , varLoc :: Location }
-  | SDummy { dumType :: Type }
-  | SExternal {extType :: Type }
+  | SVariable  { varType :: Type , varLoc :: Location }
+  | SDummy     { dumType :: Type }
+  | SExternal  { extType :: Type }
   deriving (Eq, Ord, Show, Data, Generic)
 
 instance FromJSON SymbolTableEntry


### PR DESCRIPTION
This PR adds a flag `--pretty` which gives an ASCII table summary of the memory model output, rather than the raw JSON, e.g., 
```
% fortran-vars -v Fortran77Legacy test/memory_block.f --pretty               

====================================================================================================
Program Unit: foo
====================================================================================================


+----------------------+------------+--------------------------------+-----------------+----------+------------+--------------+
| Name                 | Tag        | Type                           | Block/Value     | Offset   | Size       | Class        |
+----------------------+------------+--------------------------------+-----------------+----------+------------+--------------+
| a1                   | Variable   | integer(4)                     | a1              | 0        | 4          | Unspecified  |
| a2                   | Variable   | real(4)(Just 1:Just 3, Just... | a2              | 0        | 48         | Unspecified  |
+----------------------+------------+--------------------------------+-----------------+----------+------------+--------------+
```